### PR TITLE
cd.out_expected -> cd.expected_out

### DIFF
--- a/src/cd.test
+++ b/src/cd.test
@@ -19,7 +19,7 @@ cd ..
 printf '[%s]\n' "$PWD"
 EOT
 
-cat >cd.out_expected <<EOT
+cat >cd.expected_out <<EOT
 [$PWD]
 [$PWD/cd.dir]
 [$PWD]


### PR DESCRIPTION
fix src/cd.test error:
```
diff: cd.expected_out: No such file or directory
```
